### PR TITLE
VLC-related problem fix

### DIFF
--- a/srt.py
+++ b/srt.py
@@ -133,7 +133,7 @@ class Frame:
         f"{self.start.second},{self.start.microsecond}"\
         f" --> {self.end.hour}:{self.end.minute}:"\
         f"{self.end.second},{self.end.microsecond}"\
-        f"\n{self.caption}\n\t\n"
+        f"\n{self.caption}\n\n"
 
     def setTimecodes(self, start, end):
         if isinstance(start, time) and isinstance(end, time):


### PR DESCRIPTION
VLC media player is not able to distinguish a blank line if it contains a tab (`\t`) character. To conform to VLC, `\n\t\n` must be changed to `\n\n`